### PR TITLE
Patch for ghost turnin process running and consuming 100% CPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 ###############################################################################
 
 CC      := gcc
-CFLAGS  := -Wall -I./src
+CFLAGS  := -Wall -pthread -I./src
 LDFLAGS := -lcrypto
 EUID    := $(shell id -u -r)
 DESTDIR ?=/usr


### PR DESCRIPTION
This is a draft of a patch that fixes the `turnin` ghost processes running in the background.

The root of the bug seems to be `signore(SIGHUP)`. If for some reason a user exits the `ssh session`, `turnin` hangs at `wanttocontinue()` (infinite loop on input). 

In this patch, a new **thread** is created each time `turnin` starts. It then check  *(every 5 seconds)*, if the parent process   *(`bash`)* has terminated, and calls `exit`.

Waiting for feedback on this.