### PR TITLE
Remove requirement for root privileges when calling getpwuid()

### DIFF
--- a/src/turnin.c
+++ b/src/turnin.c
@@ -451,12 +451,6 @@ void setup(char *arg) {
 	/* get the user's login */
 	user_uid = getuid();
 
-	/* become *really* root to query the user's login */
-	if (setuid(0) == -1) {
-		perror("setuid(0)");
-		exit(2);
-	}
-
 	pwd = getpwuid(user_uid);
 
 	if (!pwd) {

--- a/src/turnin.c
+++ b/src/turnin.c
@@ -461,8 +461,6 @@ void setup(char *arg) {
 	}
 	user_name = strdup(pwd->pw_name);
 
-	be_user();
-
 	/* Search for @ in the first argument and split it there */
 	assignment = arg;
 	class = strchr(assignment, '@');


### PR DESCRIPTION
I used the following code to test `getpwuid` by replacing `another_user_id` with the ids from random students. Tested in my home directory to access other accounts.

<details>
  <summary>call getpwuid without root</summary>

```C
#define _POSIX_SOURCE
#include <sys/types.h>
#include <pwd.h>
#include <stdio.h>
#include <unistd.h>

int main() {
  struct passwd *p;
  uid_t  uid=another_user_id;

  if ((p = getpwuid(uid)) == NULL)
    perror("getpwuid() error");
  else {
    printf("getpwuid() returned the following info for uid %d:\n",
           (int) uid);
    printf("  pw_name  : %s\n",       p->pw_name);
    printf("  pw_uid   : %d\n", (int) p->pw_uid);
    printf("  pw_gid   : %d\n", (int) p->pw_gid);
    printf("  pw_dir   : %s\n",       p->pw_dir);
    printf("  pw_shell : %s\n",       p->pw_shell);
  }
}
```
</details>

Closes #40 